### PR TITLE
Allow per-task labor saving input in minutes

### DIFF
--- a/app.js
+++ b/app.js
@@ -13,11 +13,11 @@ const defaults = {
   daysTemp: 12,
   unitPrice: 14437,
   leakage: 1.0, // %
-  t1_old: 0.20, t1_new: 0.08, // 勤務入力 12分 → 5分
-  t2_old: 0.28, t2_new: 0.08, // 請求作成 17分 → 5分
-  t3_old: 0.14, t3_new: 0.05, // 給与集計 8分 → 3分
-  t4_old: 0.09, t4_new: 0.03, // 書類作成 5.4分 → 2分
-  t5_old: 0.08, t5_new: 0.02  // 連絡業務 4.8分 → 1.2分
+  t1_old: 12.0, t1_new: 4.8, // 勤務入力（分）
+  t2_old: 16.8, t2_new: 4.8, // 請求作成（分）
+  t3_old: 8.4,  t3_new: 3.0, // 給与集計（分）
+  t4_old: 5.4,  t4_new: 1.8, // 書類作成（分）
+  t5_old: 4.8,  t5_new: 1.2  // 連絡業務（分）
 };
 
 // ------- init -------
@@ -74,11 +74,11 @@ function calc() {
   const leakage   = val("leakage")/100;
 
   // task time deltas
-  const d1 = (val("t1_old") - val("t1_new")) * headcount; // 勤務入力
-  const d2 = (val("t2_old") - val("t2_new")) * invoice;   // 請求作成
-  const d3 = (val("t3_old") - val("t3_new")) * headcount; // 給与集計
-  const d4 = (val("t4_old") - val("t4_new")) * headcount; // 書類作成
-  const d5 = (val("t5_old") - val("t5_new")) * headcount; // 連絡業務
+  const d1 = ((val("t1_old") - val("t1_new")) / 60) * headcount; // 勤務入力（分→h）
+  const d2 = ((val("t2_old") - val("t2_new")) / 60) * invoice;   // 請求作成（分→h）
+  const d3 = ((val("t3_old") - val("t3_new")) / 60) * headcount; // 給与集計（分→h）
+  const d4 = ((val("t4_old") - val("t4_new")) / 60) * headcount; // 書類作成（分→h）
+  const d5 = ((val("t5_old") - val("t5_new")) / 60) * headcount; // 連絡業務（分→h）
   const sumH = Math.max(0, d1 + d2 + d3 + d4 + d5);
 
   const saveAmount = sumH * wage;

--- a/index.html
+++ b/index.html
@@ -121,37 +121,37 @@
       </div>
 
       <div class="row">
-        <label>タスク別の省力化前提（時間/単位）</label>
+        <label>タスク別の省力化前提（分/単位）</label>
         <div class="grid grid-compact">
           <div>
             <div class="hint">勤務入力：従来→ProSERIES</div>
-            <input type="number" id="t1_old" value="0.20" step="0.01" />
-            <input type="number" id="t1_new" value="0.08" step="0.01" />
-            <small class="unit">（人あたり h）例：12分 → 5分</small>
+            <input type="number" id="t1_old" value="12.0" step="0.1" />
+            <input type="number" id="t1_new" value="4.8" step="0.1" />
+            <small class="unit">（人あたり 分）例：12分 → 5分</small>
           </div>
           <div>
             <div class="hint">請求作成：従来→ProSERIES</div>
-            <input type="number" id="t2_old" value="0.28" step="0.01" />
-            <input type="number" id="t2_new" value="0.08" step="0.01" />
-            <small class="unit">（1枚あたり h）例：17分 → 5分</small>
+            <input type="number" id="t2_old" value="16.8" step="0.1" />
+            <input type="number" id="t2_new" value="4.8" step="0.1" />
+            <small class="unit">（1枚あたり 分）例：17分 → 5分</small>
           </div>
           <div>
             <div class="hint">給与集計：従来→ProSERIES</div>
-            <input type="number" id="t3_old" value="0.14" step="0.01" />
-            <input type="number" id="t3_new" value="0.05" step="0.01" />
-            <small class="unit">（人あたり h）例：8分 → 3分</small>
+            <input type="number" id="t3_old" value="8.4" step="0.1" />
+            <input type="number" id="t3_new" value="3.0" step="0.1" />
+            <small class="unit">（人あたり 分）例：8分 → 3分</small>
           </div>
           <div>
             <div class="hint">書類作成：従来→ProSERIES</div>
-            <input type="number" id="t4_old" value="0.09" step="0.01" />
-            <input type="number" id="t4_new" value="0.03" step="0.01" />
-            <small class="unit">（人あたり h）例：5.4分 → 2分</small>
+            <input type="number" id="t4_old" value="5.4" step="0.1" />
+            <input type="number" id="t4_new" value="1.8" step="0.1" />
+            <small class="unit">（人あたり 分）例：5.4分 → 2分</small>
           </div>
           <div>
             <div class="hint">連絡業務：従来→ProSERIES</div>
-            <input type="number" id="t5_old" value="0.08" step="0.01" />
-            <input type="number" id="t5_new" value="0.02" step="0.01" />
-            <small class="unit">（人あたり h）例：4.8分 → 1.2分</small>
+            <input type="number" id="t5_old" value="4.8" step="0.1" />
+            <input type="number" id="t5_new" value="1.2" step="0.1" />
+            <small class="unit">（人あたり 分）例：4.8分 → 1.2分</small>
           </div>
         </div>
       </div>


### PR DESCRIPTION
Allow task-specific time inputs to be entered in minutes, converting to hours internally for calculations.

---
<a href="https://cursor.com/background-agent?bcId=bc-09e4d915-f32e-4b19-a480-68020d5bd295">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-09e4d915-f32e-4b19-a480-68020d5bd295">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

